### PR TITLE
Update for Artifactory 4.x plus some other cleanup

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,5 +8,4 @@ artifactory_version: "3.4.2"
 artifactory_username: "artifactory"
 artifactory_password: "password"
 
-
-
+artifactory_license: oss

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@
 artifactory_database: mysql
 
 # defaults file for bbaassssiiee.artifactory
-artifactory_version: "3.4.2"
+artifactory_version: "4.5.1"
 artifactory_username: "artifactory"
 artifactory_password: "password"
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,11 +1,11 @@
 ---
 # handlers file for bbaassssiiee.artifactory
 - name: 'start artifactory'
-  sudo: yes
+  become: yes
   service: name=artifactory state=started
   tags:
     - init
 
 - name: 'restart artifactory'
-  sudo: yes
+  become: yes
   service: name=artifactory state=restarted

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -80,3 +80,6 @@
   command: "{{artifactory_home}}/bin/installService.sh {{artifactory_username}}"
   notify:
     - 'restart artifactory'
+
+- name: 'enable artifactory service'
+  service: name=artifactory enabled=true

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -36,7 +36,8 @@
 
 - name: 'verify if an update is needed'
   shell: "ls -1d /opt/artifactory/artifactory-{{artifactory_license}}-* | grep -v artifactory-{{artifactory_license}}-{{artifactory_version}}"
-  ignore_errors: yes
+  failed_when: false
+  changed_when: false
   register: previous
 
 - name: 'stop artifactory before upgrade'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -13,9 +13,8 @@
     that:
       - "'java version' in java.stderr"
 
-# download artifactory http://bit.ly/Hqv9aj
-- name: 'make sure directory exists for artifactory'
-  file: dest=/opt/artifactory state=directory mode=0755
+- name: 'create user to run artifactory'
+  user: name={{artifactory_username}} home=/opt/artifactory/ shell=/bin/false system=true
 
 - name: 'verify presence of artifactory'
   stat: path="/opt/artifactory/artifactory-{{artifactory_version}}/webapps/artifactory.war"
@@ -60,9 +59,6 @@
 #- name: 'cleanup artifactory download'
 #  file: dest=/tmp/{{artifactory_file}} state=absent
 #  when: artifactory_download.stat.exists
-
-- name: 'create user to run artifactory'
-  user: name={{artifactory_username}}
 
 - name: 'create config dir for artifactory'
   file: dest=/etc/opt/jfrog/artifactory state=directory owner=root mode=0755

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -9,9 +9,9 @@
   tags:
     - verify
 
-- assert: 
-    that: 
-      - "'java version' in java.stderr" 
+- assert:
+    that:
+      - "'java version' in java.stderr"
 
 # download artifactory http://bit.ly/Hqv9aj
 - name: 'make sure directory exists for artifactory'
@@ -59,7 +59,6 @@
 #- name: 'cleanup artifactory download'
 #  file: dest=/tmp/{{artifactory_file}} state=absent
 #  when: artifactory_download.stat.exists
-
 
 - name: 'create user to run artifactory'
   user: name={{artifactory_username}}

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -70,6 +70,11 @@
   template: src=etc-opt-jfrog-artifactory-default.j2 dest=/etc/opt/jfrog/artifactory/default
                 owner=root group=root mode=0644
 
+- name: 'symlink current version'
+  file:
+    state=link
+    dest=/opt/artifactory/artifactory
+    src=/opt/artifactory/artifactory-{{artifactory_license}}-{{artifactory_version}}
 
 - name: 'install artifactory as a service'
   command: "{{artifactory_home}}/bin/installService.sh {{artifactory_username}}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -35,7 +35,7 @@
   when: not jarfile.stat.exists
 
 - name: 'verify if an update is needed'
-  shell: "ls -1d /opt/artifactory/artifactory-* | grep -v artifactory-{{artifactory_version}}"
+  shell: "ls -1d /opt/artifactory/artifactory-{{artifactory_license}}-* | grep -v artifactory-{{artifactory_license}}-{{artifactory_version}}"
   ignore_errors: yes
   register: previous
 
@@ -44,7 +44,7 @@
   when: previous.stdout
 
 - name: 'move artifactory data folder'
-  shell: mv {{ previous.stdout }}/data /opt/artifactory/artifactory-{{artifactory_version}}
+  shell: mv {{ previous.stdout }}/data /opt/artifactory/artifactory-{{artifactory_license}}-{{artifactory_version}}
   notify: restart artifactory
   when: previous.stdout
 

--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -32,4 +32,4 @@
     password={{ artifactory_password }}
 
 - name: 'enable mysql driver'
-  template: src=storage_mysql.j2 dest={{artifactory_home}}/etc/storage.properties owner=root group=root mode=0644
+  template: src=storage_mysql.j2 dest={{artifactory_home}}/etc/storage.properties owner=artifactory group=artifactory mode=0600

--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -14,5 +14,5 @@
   register: jdbc_installed
 
 - name: 'enable postgresql driver'
-  template: src=storage_postgresql.j2 dest={{artifactory_home}}/etc/storage.properties owner=root group=root mode=0644
+  template: src=storage_postgresql.j2 dest={{artifactory_home}}/etc/storage.properties owner=artifactory group=artifactory mode=0600
 

--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -4,6 +4,7 @@
   when: ansible_os_family == "RedHat"
 
 - name: 'create artifactory database user in postgres'
+  become_user: postgres
   postgresql_user: db=artifactory name='{{artifactory_username}}' password='{{artifactory_password}}'
 
 - name: 'create artifactory database in postgres'

--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -3,11 +3,12 @@
   yum: name=python-psycopg2 state=installed
   when: ansible_os_family == "RedHat"
 
-- name: 'create artifactory database in postgres'
-  postgresql_db: name=artifactory template='template0' encoding='UTF-8'
-
 - name: 'create artifactory database user in postgres'
   postgresql_user: db=artifactory name='{{artifactory_username}}' password='{{artifactory_password}}'
+
+- name: 'create artifactory database in postgres'
+  become_user: postgres
+  postgresql_db: name=artifactory owner=artifactory template='template0' encoding='UTF-8'
 
 - name: 'download jdbc connector for postgres'
   get_url: url={{postgres_jdbc_url}} dest={{artifactory_home}}/tomcat/lib

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,8 +1,8 @@
 ---
 
-artifactory_url: "https://bintray.com/artifact/download/jfrog/artifactory/artifactory-{{artifactory_version}}.zip"
+artifactory_url: "https://bintray.com/artifact/download/jfrog/artifactory/jfrog-artifactory-{{artifactory_license}}-{{artifactory_version}}.zip"
 artifactory_file: "artifactory-{{artifactory_version}}.zip"
-artifactory_home: "/opt/artifactory/artifactory-{{artifactory_version}}"
+artifactory_home: "/opt/artifactory/artifactory-{{artifactory_license}}-{{artifactory_version}}"
 
 postgres_jdbc_url: "http://jdbc.postgresql.org/download/postgresql-9.3-1102.jdbc4.jar"
 


### PR DESCRIPTION
I think starting with Artifactory v4.0 they began naming their release zip files differently. This update uses the new naming scheme. This also now supports the new release types (oss, pro, registry). In addition it defaults to the latest current release (4.5.1).

I also updated some of the tasks to be more forgiving of individual configuration differences, stopped using the Ansible deprecated 'sudo' meta param, squashed some errors, fixed configuration file permissions, enabled the service for reboots, and finally symlinked the current Artifactory version.
