### PR TITLE
Minor fixes

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -14,7 +14,7 @@
       - "'java version' in java.stderr"
 
 - name: 'create user to run artifactory'
-  user: name={{artifactory_username}} home=/opt/artifactory/ shell=/bin/false system=true
+  user: name={{artifactory_username}} home=/opt/artifactory/ shell=/bin/bash system=true
 
 - name: 'verify presence of artifactory'
   stat: path="/opt/artifactory/artifactory-{{artifactory_version}}/webapps/artifactory.war"

--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -1,7 +1,7 @@
 
 - name: 'make sure postgres dependencies are installed'
-  yum: name=python-psycopg2 state=installed
-  when: ansible_os_family == "RedHat"
+  package: name=python-psycopg2 state=installed
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
 
 - name: 'create artifactory database user in postgres'
   become_user: postgres

--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -5,7 +5,7 @@
 
 - name: 'create artifactory database user in postgres'
   become_user: postgres
-  postgresql_user: db=artifactory name='{{artifactory_username}}' password='{{artifactory_password}}'
+  postgresql_user: name='{{artifactory_username}}' password='{{artifactory_password}}'
 
 - name: 'create artifactory database in postgres'
   become_user: postgres


### PR DESCRIPTION
User needs a valid shell otherwise init script doesn't work properly. We need python-psycopg2 on Debian too. Don't set the db on the postgres user.
