### PR TITLE
Install the unzip package as a prerequesites. Use the yum module to install rpms

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -15,13 +15,20 @@
       - "'version' in java.stderr"
 
 - name: yum install prerequesites
-  command: yum install -y openssl
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - openssl
+    - unzip
   tags:
     - artifactory
   when: ansible_os_family == "RedHat"
 
 - name: yum install net-tools
-  command: yum install -y net-tools
+  yum:
+    name: net-tools
+    state: present
   tags:
     - artifactory
   when: ansible_os_family == "RedHat"


### PR DESCRIPTION
I'd just spun up a fresh RHEL-7.3_HVM_GA-20161026-x86_64-1-Hourly2-GP2 and it didn't have `unzip` available. This is after include geerlingguy.java and geerlingguy.postgresql to bring in the other prerequesites. 
Ultimately a package approach that geerlingguy mentioned in his talk, https://www.ansible.com/ansible-roles-by-acquia would a better option. I'm a bit short on time to implement this as the moment though.